### PR TITLE
use absolute URLs in atom.xml and fix broken URL

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -7,7 +7,7 @@ layout: null
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ '/' | absolute_url }}</link>
-    <atom:link href="{{ 'feed.xml' | absolute_url }}" rel="self" type="application/rss+xml" />
+    <atom:link href="{{ 'atom.xml' | absolute_url }}" rel="self" type="application/rss+xml" />
     <author>
       <name>{{ site.author.name }}</name>
       <email>{{ site.author.email }}</email>

--- a/atom.xml
+++ b/atom.xml
@@ -6,8 +6,8 @@ layout: null
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.url }}</link>
-    <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
+    <link>{{ '/' | absolute_url }}</link>
+    <atom:link href="{{ 'feed.xml' | absolute_url }}" rel="self" type="application/rss+xml" />
     <author>
       <name>{{ site.author.name }}</name>
       <email>{{ site.author.email }}</email>
@@ -18,9 +18,10 @@ layout: null
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
-        <link>{{ site.url }}/{{ post.url }}</link>
-        <link href="{{ site.url }}{{ post.url }}"/>
-        <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+        {% assign post_url = post.url | absolute_url %}
+        <link>{{ post_url }}</link>
+        <link href="{{ post_url }}"/>
+        <guid isPermaLink="true">{{ post_url }}</guid>
       </item>
     {% endfor %}
   </channel>


### PR DESCRIPTION
## Refactor

Adding `site.url` is not a good pattern in Jekyll.

In particular, if someone uses this repo on a subpath, the code would break, because `site.url` does _not_ include `site.baseurl.`

If you do this:

```
{{ post.url | absolute_url }}
```

That uses the site.url and site.baseurl values for you

e.g. I tested locally and got:

```html
<link>https://michaelcurrin.github.io/jekyll-blog-demo/jekyll/update/2018/12/18/welcome-to-jekyll/</link>
```

I also refactored the other parts not around posts, to use `absolute_url`.

Note that when running locally you should do this, so that `site.url` is used as domain instead of localhost.

```sh
JEKYLL_ENV=production bundle exec jekyll build --trace
```

## Fix

I replaced feed.xml with atom.xml in the file.